### PR TITLE
Adding TravisCI testing to Hostmaster repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,73 @@
+language: generic
+
+sudo: required
+
+env:
+  globaL:
+    - DOCKER_VERSION=1.11.2-0~trusty
+    - DOCKER_COMPOSE_VERSION=1.7.1
+    - AEGIR_TESTS_VERSION
+
+#env:
+#  - test: Ubuntu 14.04 Apache
+#    distribution: ubuntu
+#    version: 14.04
+#    init: /sbin/init
+#    run_opts: ""
+
+addons:
+  hosts:
+    - aegir.travis
+    - sitetest.aegir.travis
+
+services:
+  - docker
+
+before_install:
+
+  # Get test scripts
+  - git clone git@github.com:aegir-project/tests.git
+  - cd tests
+
+  #  Build a makefile for this hostmaster clone.
+  - echo projects[hostmaster][download][type] = "copy" >> build-hostmaster.make
+  - echo projects[hostmaster][download][url] = "$TRAVIS_BUILD_DIR" >> build-hostmaster.make
+  - cat build-hostmaster.make
+  - cd ..
+
+  # list docker-engine versions
+  - apt-cache madison docker-engine
+
+  # upgrade docker-engine to specific version
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+
+  # reinstall docker-compose at specific version
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - docker --version
+  - docker-compose --version
+
+  # Get aegir/hostmaster image.
+  - sudo docker pull aegir/hostmaster
+
+
+script:
+#  - 'sudo docker run --detach --name aegir_hostmaster -h aegir.travis --add-host "sitetest.aegir.travis":127.0.0.1 ${distribution}-${version}:ansible "${init}"'
+  - 'git clone git@github.com:aegir-project/tests.git'
+  - 'cd tests'
+
+  # The test run is included in the docker-entrypoint-tests.sh file.
+  - 'sudo docker-compose up --abort-on-container-exit'
+
+  # Turn off hosting queued, and the hosting task queue.
+#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster dis hosting_queued -y -v"'
+#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster vset hosting_queue_tasks_enabled 0 -y"'
+
+  # Build and Run Tests
+#  - 'sudo docker exec aegir_hostmaster env TERM=xterm sudo su - -c "cd /usr/share/devshop/tests && composer update"'
+#  - 'sudo docker exec devshop_container env TERM=xterm sudo su - aegir -c "devshop devmaster:test"'
+
+  # Stop container.
+  - 'sudo docker-compose stop'

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ before_install:
 
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
-
   - echo $TRAVIS_BUILD_DIR
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   globaL:
     - DOCKER_VERSION=1.11.2-0~trusty
     - DOCKER_COMPOSE_VERSION=1.7.1
-    - AEGIR_TESTS_VERSION
+    - AEGIR_HOSTING_VERSION=7.x-3.x
+    - AEGIR_TESTS_VERSION=master
 
 #env:
 #  - test: Ubuntu 14.04 Apache
@@ -25,9 +26,15 @@ services:
 
 before_install:
 
+  # Get Hosting
+  - git clone http://git.drupal.org/project/hosting.git /home/travis/build/aegir-project/hosting
+  - cd /home/travis/build/aegir-project/hosting
+  - git checkout $AEGIR_HOSTING_VERSION
+
   # Get test scripts
-  - git clone http://github.com/aegir-project/tests.git
-  - cd tests/travis
+  - git clone http://github.com/aegir-project/tests.git /home/travis/build/aegir-project/tests
+  - cd /home/travis/build/aegir-project/tests
+  - git checkout $AEGIR_TESTS_VERSION
 
   # list docker-engine versions
   - apt-cache madison docker-engine

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ services:
   - docker
 
 before_install:
+  # Show travis build dir variable.
+  - echo $TRAVIS_BUILD_DIR
 
   # Get test scripts
   - git clone http://github.com/aegir-project/tests.git
@@ -43,10 +45,9 @@ before_install:
   - docker --version
   - docker-compose --version
 
-  # Get aegir/hostmaster image.
+  # Get aegir/hostmaster and database images.
   - sudo docker pull aegir/hostmaster
   - sudo docker pull mariadb
-  - echo $TRAVIS_BUILD_DIR
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - apt-cache madison docker-engine
 
   # upgrade docker-engine to specific version
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+  - sudo apt-get -qq -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
 
   # reinstall docker-compose at specific version
   - sudo rm /usr/local/bin/docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - DOCKER_VERSION=1.11.2-0~trusty
     - DOCKER_COMPOSE_VERSION=1.7.1
     - AEGIR_HOSTING_VERSION=7.x-3.x
-    - AEGIR_TESTS_VERSION=master
+    - AEGIR_TESTS_VERSION=source-path
 
 #env:
 #  - test: Ubuntu 14.04 Apache

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ before_install:
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
 
+  - echo $TRAVIS_BUILD_DIR
+
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ services:
 before_install:
 
   # Get test scripts
-  - git clone git@github.com:aegir-project/tests.git
+  - git clone http://github.com/aegir-project/tests.git
   - cd tests
 
   #  Build a makefile for this hostmaster clone.

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,20 +54,7 @@ before_install:
 
 
 script:
-#  - 'sudo docker run --detach --name aegir_hostmaster -h aegir.travis --add-host "sitetest.aegir.travis":127.0.0.1 ${distribution}-${version}:ansible "${init}"'
-  - 'git clone git@github.com:aegir-project/tests.git'
-  - 'cd tests'
 
-  # The test run is included in the docker-entrypoint-tests.sh file.
-  - 'sudo docker-compose up --abort-on-container-exit'
-
-  # Turn off hosting queued, and the hosting task queue.
-#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster dis hosting_queued -y -v"'
-#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster vset hosting_queue_tasks_enabled 0 -y"'
-
-  # Build and Run Tests
-#  - 'sudo docker exec aegir_hostmaster env TERM=xterm sudo su - -c "cd /usr/share/devshop/tests && composer update"'
-#  - 'sudo docker exec devshop_container env TERM=xterm sudo su - aegir -c "devshop devmaster:test"'
-
-  # Stop container.
-  - 'sudo docker-compose stop'
+  # Tests are included in the docker-compose.yml file in the tests repo.
+  - cd tests
+  - sudo docker-compose run hostmaster --rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
 
-
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,7 @@ before_install:
 
   # Get test scripts
   - git clone http://github.com/aegir-project/tests.git
-  - cd tests
-
-  #  Build a makefile for this hostmaster clone.
-  - echo projects[hostmaster][download][type] = "copy" >> build-hostmaster.make
-  - echo projects[hostmaster][download][url] = "$TRAVIS_BUILD_DIR" >> build-hostmaster.make
-  - cat build-hostmaster.make
-  - cd ..
+  - cd tests/travis
 
   # list docker-engine versions
   - apt-cache madison docker-engine
@@ -56,5 +50,4 @@ before_install:
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.
-  - cd tests
   - sudo docker-compose run hostmaster --rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_install:
 
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
+  - sudo docker pull mariadb
   - echo $TRAVIS_BUILD_DIR
 
 script:


### PR DESCRIPTION
This PR adds a .travis.yml file that launches docker containers from aegir/hostmaster and runs the tests.

More to do:
- Launch the hostmaster container using the build-hostmaster.makefile found in the submitted codebase.
- ?
