### PR TITLE
Add node_access_rebuild() to hostmaster.install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,73 @@
+language: generic
+
+sudo: required
+
+env:
+  globaL:
+    - DOCKER_VERSION=1.11.2-0~trusty
+    - DOCKER_COMPOSE_VERSION=1.7.1
+    - AEGIR_TESTS_VERSION
+
+#env:
+#  - test: Ubuntu 14.04 Apache
+#    distribution: ubuntu
+#    version: 14.04
+#    init: /sbin/init
+#    run_opts: ""
+
+addons:
+  hosts:
+    - aegir.travis
+    - sitetest.aegir.travis
+
+services:
+  - docker
+
+before_install:
+
+  # Get test scripts
+  - git clone git@github.com:aegir-project/tests.git
+  - cd tests
+
+  #  Build a makefile for this hostmaster clone.
+  - echo projects[hostmaster][download][type] = "copy" >> build-hostmaster.make
+  - echo projects[hostmaster][download][url] = "$TRAVIS_BUILD_DIR" >> build-hostmaster.make
+  - cat build-hostmaster.make
+  - cd ..
+
+  # list docker-engine versions
+  - apt-cache madison docker-engine
+
+  # upgrade docker-engine to specific version
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=${DOCKER_VERSION}
+
+  # reinstall docker-compose at specific version
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  - docker --version
+  - docker-compose --version
+
+  # Get aegir/hostmaster image.
+  - sudo docker pull aegir/hostmaster
+
+
+script:
+#  - 'sudo docker run --detach --name aegir_hostmaster -h aegir.travis --add-host "sitetest.aegir.travis":127.0.0.1 ${distribution}-${version}:ansible "${init}"'
+  - 'git clone git@github.com:aegir-project/tests.git'
+  - 'cd tests'
+
+  # The test run is included in the docker-entrypoint-tests.sh file.
+  - 'sudo docker-compose up --abort-on-container-exit'
+
+  # Turn off hosting queued, and the hosting task queue.
+#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster dis hosting_queued -y -v"'
+#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster vset hosting_queue_tasks_enabled 0 -y"'
+
+  # Build and Run Tests
+#  - 'sudo docker exec aegir_hostmaster env TERM=xterm sudo su - -c "cd /usr/share/devshop/tests && composer update"'
+#  - 'sudo docker exec devshop_container env TERM=xterm sudo su - aegir -c "devshop devmaster:test"'
+
+  # Stop container.
+  - 'sudo docker-compose stop'

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ before_install:
 
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
-
   - echo $TRAVIS_BUILD_DIR
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ services:
   - docker
 
 before_install:
+  # Show travis build dir variable.
+  - echo $TRAVIS_BUILD_DIR
 
   # Get test scripts
   - git clone http://github.com/aegir-project/tests.git
@@ -43,10 +45,9 @@ before_install:
   - docker --version
   - docker-compose --version
 
-  # Get aegir/hostmaster image.
+  # Get aegir/hostmaster and database images.
   - sudo docker pull aegir/hostmaster
   - sudo docker pull mariadb
-  - echo $TRAVIS_BUILD_DIR
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ before_install:
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
 
+  - echo $TRAVIS_BUILD_DIR
+
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ services:
 before_install:
 
   # Get test scripts
-  - git clone git@github.com:aegir-project/tests.git
+  - git clone http://github.com/aegir-project/tests.git
   - cd tests
 
   #  Build a makefile for this hostmaster clone.

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,20 +54,7 @@ before_install:
 
 
 script:
-#  - 'sudo docker run --detach --name aegir_hostmaster -h aegir.travis --add-host "sitetest.aegir.travis":127.0.0.1 ${distribution}-${version}:ansible "${init}"'
-  - 'git clone git@github.com:aegir-project/tests.git'
-  - 'cd tests'
 
-  # The test run is included in the docker-entrypoint-tests.sh file.
-  - 'sudo docker-compose up --abort-on-container-exit'
-
-  # Turn off hosting queued, and the hosting task queue.
-#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster dis hosting_queued -y -v"'
-#  - 'sudo docker exec aegir_hostmaster env sudo su - aegir -c "drush @hostmaster vset hosting_queue_tasks_enabled 0 -y"'
-
-  # Build and Run Tests
-#  - 'sudo docker exec aegir_hostmaster env TERM=xterm sudo su - -c "cd /usr/share/devshop/tests && composer update"'
-#  - 'sudo docker exec devshop_container env TERM=xterm sudo su - aegir -c "devshop devmaster:test"'
-
-  # Stop container.
-  - 'sudo docker-compose stop'
+  # Tests are included in the docker-compose.yml file in the tests repo.
+  - cd tests
+  - sudo docker-compose run hostmaster --rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ before_install:
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
 
-
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,7 @@ before_install:
 
   # Get test scripts
   - git clone http://github.com/aegir-project/tests.git
-  - cd tests
-
-  #  Build a makefile for this hostmaster clone.
-  - echo projects[hostmaster][download][type] = "copy" >> build-hostmaster.make
-  - echo projects[hostmaster][download][url] = "$TRAVIS_BUILD_DIR" >> build-hostmaster.make
-  - cat build-hostmaster.make
-  - cd ..
+  - cd tests/travis
 
   # list docker-engine versions
   - apt-cache madison docker-engine
@@ -56,5 +50,4 @@ before_install:
 script:
 
   # Tests are included in the docker-compose.yml file in the tests repo.
-  - cd tests
   - sudo docker-compose run hostmaster --rm

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_install:
 
   # Get aegir/hostmaster image.
   - sudo docker pull aegir/hostmaster
+  - sudo docker pull mariadb
   - echo $TRAVIS_BUILD_DIR
 
 script:

--- a/hostmaster.install
+++ b/hostmaster.install
@@ -223,6 +223,8 @@ function hostmaster_task_finalize() {
   variable_set('menu_options_server', array());
   variable_set('menu_options_site', array());
 
+  // Rebuild node access permissions.
+  node_access_rebuild();
 }
 
 /**


### PR DESCRIPTION
At the end of every Aegir install, you are confronted with a message:

![screen shot 2016-07-28 at 10 26 34 am](https://cloud.githubusercontent.com/assets/106420/17216423/9b483e70-54ae-11e6-8773-d63f847f46f4.png)

> The content access permissions need to be rebuilt.

Turns out this was in place for aegir 1.x and 2.x.  I finally tracked down where it was removed: https://github.com/aegir-project/hostmaster/commit/8d4798fc6ea94fce1f333724b09d045699160d7d#diff-1b4732042832a44c3aa98e72063a3e67  https://www.drupal.org/node/2041911

Taking this opportunity to make our first pull request.
